### PR TITLE
WSD-1035-fix-the-unsynchronized-sci_viz-image-topic-in-sim

### DIFF
--- a/avt_vimba_camera/src/mono_camera_sim_node.cpp
+++ b/avt_vimba_camera/src/mono_camera_sim_node.cpp
@@ -33,6 +33,11 @@ public:
     // Setup camera info
     setupCameraInfo();
 
+    // Pre-convert image message once to avoid overhead in callback
+    std_msgs::msg::Header header;
+    header.frame_id = "camera_optical_frame";
+    image_msg_ = cv_bridge::CvImage(header, "bgr8", image_).toImageMsg();
+
     // Timer to publish at 10 Hz
     timer_ =
         this->create_wall_timer(std::chrono::milliseconds(100), std::bind(&MonoCameraSimNode::timer_callback, this));
@@ -69,12 +74,9 @@ private:
   {
     auto stamp = this->get_clock()->now();
     
-    // Publish image
-    std_msgs::msg::Header header;
-    header.stamp = stamp;
-    header.frame_id = "camera_optical_frame";
-    auto msg = cv_bridge::CvImage(header, "bgr8", image_).toImageMsg();
-    publisher_->publish(*msg);
+    // Update timestamp and publish image
+    image_msg_->header.stamp = stamp;
+    publisher_->publish(*image_msg_);
     
     // Publish camera info
     cam_info_.header.stamp = stamp;
@@ -85,6 +87,7 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr cam_info_publisher_;
   rclcpp::TimerBase::SharedPtr timer_;
   cv::Mat image_;
+  sensor_msgs::msg::Image::SharedPtr image_msg_;
   sensor_msgs::msg::CameraInfo cam_info_;
 };
 

--- a/avt_vimba_camera/src/mono_camera_sim_node.cpp
+++ b/avt_vimba_camera/src/mono_camera_sim_node.cpp
@@ -10,9 +10,13 @@ class MonoCameraSimNode : public rclcpp::Node
 public:
   MonoCameraSimNode() : Node("mono_camera_sim_node")
   {
-    // create publishers
-    publisher_ = this->create_publisher<sensor_msgs::msg::Image>("/sci_viz_image_raw", 10);
-    cam_info_publisher_ = this->create_publisher<sensor_msgs::msg::CameraInfo>("/sci_viz_cam_info", 10);
+    // create publishers with QoS settings appropriate for sensor data
+    auto qos = rclcpp::QoS(rclcpp::KeepLast(10));
+    qos.reliability(rclcpp::ReliabilityPolicy::Reliable);
+    qos.durability(rclcpp::DurabilityPolicy::Volatile);
+    
+    publisher_ = this->create_publisher<sensor_msgs::msg::Image>("/sci_viz_image_raw", qos);
+    cam_info_publisher_ = this->create_publisher<sensor_msgs::msg::CameraInfo>("/sci_viz_cam_info", qos);
 
     // Load image from disk
     std::string package_path = ament_index_cpp::get_package_share_directory("avt_vimba_camera");
@@ -66,8 +70,10 @@ private:
     auto stamp = this->get_clock()->now();
     
     // Publish image
-    auto msg = cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", image_).toImageMsg();
-    msg->header.stamp = stamp;
+    std_msgs::msg::Header header;
+    header.stamp = stamp;
+    header.frame_id = "camera_optical_frame";
+    auto msg = cv_bridge::CvImage(header, "bgr8", image_).toImageMsg();
     publisher_->publish(*msg);
     
     // Publish camera info

--- a/avt_vimba_camera/src/mono_camera_sim_node.cpp
+++ b/avt_vimba_camera/src/mono_camera_sim_node.cpp
@@ -1,5 +1,6 @@
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <opencv2/opencv.hpp>
 #include <ament_index_cpp/get_package_share_directory.hpp>
@@ -9,8 +10,9 @@ class MonoCameraSimNode : public rclcpp::Node
 public:
   MonoCameraSimNode() : Node("mono_camera_sim_node")
   {
-    // create publisher
+    // create publishers
     publisher_ = this->create_publisher<sensor_msgs::msg::Image>("/sci_viz_image_raw", 10);
+    cam_info_publisher_ = this->create_publisher<sensor_msgs::msg::CameraInfo>("/sci_viz_cam_info", 10);
 
     // Load image from disk
     std::string package_path = ament_index_cpp::get_package_share_directory("avt_vimba_camera");
@@ -24,22 +26,60 @@ public:
       return;
     }
 
+    // Setup camera info
+    setupCameraInfo();
+
     // Timer to publish at 10 Hz
     timer_ =
         this->create_wall_timer(std::chrono::milliseconds(100), std::bind(&MonoCameraSimNode::timer_callback, this));
   }
 
 private:
+  void setupCameraInfo()
+  {
+    cam_info_.header.frame_id = "camera_optical_frame";
+    cam_info_.width = image_.cols;
+    cam_info_.height = image_.rows;
+    
+    // Example camera matrix (intrinsics) - adjust these values as needed
+    cam_info_.k = {1000.0, 0.0, static_cast<double>(image_.cols / 2),
+                   0.0, 1000.0, static_cast<double>(image_.rows / 2),
+                   0.0, 0.0, 1.0};
+    
+    // Distortion coefficients (k1, k2, t1, t2, k3)
+    cam_info_.d = {0.0, 0.0, 0.0, 0.0, 0.0};
+    cam_info_.distortion_model = "plumb_bob";
+    
+    // Rectification matrix (identity for monocular camera)
+    cam_info_.r = {1.0, 0.0, 0.0,
+                   0.0, 1.0, 0.0,
+                   0.0, 0.0, 1.0};
+    
+    // Projection matrix
+    cam_info_.p = {1000.0, 0.0, static_cast<double>(image_.cols / 2), 0.0,
+                   0.0, 1000.0, static_cast<double>(image_.rows / 2), 0.0,
+                   0.0, 0.0, 1.0, 0.0};
+  }
+
   void timer_callback()
   {
+    auto stamp = this->get_clock()->now();
+    
+    // Publish image
     auto msg = cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", image_).toImageMsg();
-    msg->header.stamp = this->get_clock()->now();
+    msg->header.stamp = stamp;
     publisher_->publish(*msg);
+    
+    // Publish camera info
+    cam_info_.header.stamp = stamp;
+    cam_info_publisher_->publish(cam_info_);
   }
 
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr publisher_;
+  rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr cam_info_publisher_;
   rclcpp::TimerBase::SharedPtr timer_;
   cv::Mat image_;
+  sensor_msgs::msg::CameraInfo cam_info_;
 };
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
## Summary
Currently we get the following error in sim-

[component_container-3] [WARN] [1772577664.177859935] [rectify_node]: [image_transport] Topics '/sci_viz_image_raw' and '/camera_info' do not appear to be synchronized. In the last 10s:
[component_container-3] 	Image messages received:      10
[component_container-3] 	CameraInfo messages received: 0
[component_container-3] 	Synchronized pairs:           0


## Jira
- Ticket: https://wsrobots.atlassian.net/browse/WSD-1035

## Context / Links
- Related PRs:
https://github.com/WILDER-SYSTEMS-LLC/avt_vimba_camera/pull/7
https://github.com/WILDER-SYSTEMS-LLC/scissor_tail/pull/169